### PR TITLE
Taken care of overflow problem

### DIFF
--- a/R/samr.morefuns.R
+++ b/R/samr.morefuns.R
@@ -1481,7 +1481,7 @@ quant <- function(x) {
 ######################################################################
 samr.estimate.depth <- function(x) {
 	iter <- 5
-	cmeans <- colSums(x)/sum(x)
+	cmeans <- colSums(x)/sum(as.numeric(x))
 	for (i in 1:iter) {
 		n0 <- rowSums(x) %*% t(cmeans)
 		prop <- rowSums((x - n0)^2/(n0 + 1e-08))


### PR DESCRIPTION
When the sum exceeds the 32 bit limit, then following error occurs
"Error in quantile.default(prop, c(0.25, 0.75)) : 
  missing values and NaN's not allowed if 'na.rm' is FALSE " 
So to take care of that convert it into double